### PR TITLE
Removed set header h2 padding block, left 1rem padding inline

### DIFF
--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -20,7 +20,7 @@ const Page = ({ children, classList = '', name, hasHeader = true, hasBanner = fa
                     {component}
                     </header>
             }
-            <main className={`padding-inline-1 ${main ? main.style : ''}`}>
+            <main className={`${main ? main.style : ''}`}>
                 {children}
             </main>
         </div>

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1155,7 +1155,7 @@ height: 2rem;
   align-items: center;
   max-width: 135rem;
   margin-inline: auto;
-  padding-inline: 2rem;
+  padding-inline: 1rem;
   min-height: 3rem;
   width: 100%;
 }
@@ -1825,7 +1825,7 @@ text-align: center;
 
 .page-header  {
   color: var(--clr-dark);
-  padding: 1rem;
+  /* padding: 1rem; */
    margin-bottom: 1rem;
 }
 
@@ -1893,7 +1893,7 @@ text-align: center;
   display: flex;
   justify-content: center;
   align-items: center;
-  min-height: 3.5rem;
+  min-height: 3.7rem;
   background: var(--clr-eclipse);
   border-radius: 5px;
 }


### PR DESCRIPTION
Reduced font size of h2 set name. 
Uncommented min height of set header to 3.5rem.
Removed padding block to set header h2,
Removed Page component 1rem padding inline.
Reduced breadcrumbs padding inline from 2rem to 1rem.
Removed padding padding (inline and block) from page-header selector.

Goal: Fitting longer set names inside set headers h2. 
