### PR TITLE
Removed set header h2 padding block, left 1rem padding inline

### DIFF
--- a/src/features/search/components/Set.js
+++ b/src/features/search/components/Set.js
@@ -3,13 +3,13 @@ import Print from './Print';
 import useImageLoader from '../../../hooks/useImageLoader';
 import useSearch from '../../../hooks/contexthooks/useSearch'
 
-const Set = ({ collection }) => {
+const Set = ({ set }) => {
     const [hasLoaded, setHasLoaded] = useState(false);
     const { cardSets } = useSearch();
 
-    console.log(cardSets[collection.id])
+    console.log(cardSets[set.id])
 
-    const [imagesLoaded] = useImageLoader(collection.prints);
+    const [imagesLoaded] = useImageLoader(set.prints);
 
     return (
         <div className="set">
@@ -17,17 +17,17 @@ const Set = ({ collection }) => {
                 <h2>
                     {
                         // imagesLoaded &&
-                        <span className='set-icon' style={{ maskImage: `url(${cardSets[collection.id]?.icon_svg_uri})`, WebkitMaskImage: `url(${cardSets[collection.id]?.icon_svg_uri})` }}>
+                        <span className='set-icon' style={{ maskImage: `url(${cardSets[set.id]?.icon_svg_uri})`, WebkitMaskImage: `url(${cardSets[set.id]?.icon_svg_uri})` }}>
 
-                            {/* <img className='icon' src={`${cardSets[collection.set]?.icon_svg_uri}`} style={{ fill: 'red' }} onload='SVGInject(this)' alt='Set icon' /> */}
-                    </span>
+                            {/* <img className='icon' src={`${cardSets[set.set]?.icon_svg_uri}`} style={{ fill: 'red' }} onload='SVGInject(this)' alt='Set icon' /> */}
+                        </span>
                     }
-                    <span className='set-name'>{cardSets[collection.id]?.name}</span>
+                    <span className='set-name'>{cardSets[set.id]?.name}</span>
                 </h2>
             </div>
             <div className='set-prints'>
                 {
-                    collection?.prints.map((print, i) => {
+                    set?.prints.map((print, i) => {
                         return <Print key={i} print={print} />
                     })
                 }

--- a/src/hooks/useResult.js
+++ b/src/hooks/useResult.js
@@ -52,7 +52,7 @@ const useResult = (search) => {
 
         console.log(result)
 
-        setSearchResult(result.map((collection, i) => <Set key={i} collection={collection} />))
+        setSearchResult(result.map((set, i) => <Set key={i} set={set} />))
 
     }
     function handleCatalog(query, result) { }


### PR DESCRIPTION
Reduced font size of h2 set name. 
Uncommented min height of set header to 3.5rem.
Removed padding block to set header h2,
Removed Page component 1rem padding inline.
Reduced breadcrumbs padding inline from 2rem to 1rem.
Removed padding padding (inline and block) from page-header selector.
Replace naming convention from 'collection' to  'set' @useResult hook & Set component. 

Goal: Fitting longer set names inside set headers h2. 
