### PR TITLE
Removed set header h2 padding block, left 1rem padding inline

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -1,24 +1,25 @@
 import useLazyLoader from '../hooks/useLazyLoader';
 
-const Image = ({ classList, product }) => {
-    const { hasLoaded } = useLazyLoader(product);
+const Image = ({ classList, src }) => {
+// const { hasLoaded } = useLazyLoader(src);
 
     return (
         <figure className='product-view'>
-            <div className={`product-view-container ${product.finishes?.includes('foil') && 'is-foil'}`}>
+            <div className={`product-view-container`}>
+                {/* <div className={`product-view-container ${product.finishes?.includes('foil') && 'is-foil'}`}> */}
                 {
-                    !hasLoaded ? (
-                        <img src={require('../assets/img/mtg_card_back.jpg')} alt='Magic back card' />
-                    ) : (
+                    // !hasLoaded ? (
+                    //     <img src={require('../assets/img/mtg_card_back.jpg')} alt='Magic back card' />
+                    // ) : (
                         // <Link to={`/product/${product.name}`}>
                         <img
                             className={classList}
-                            src={product.image_uris?.normal || product.card_faces[0].image_uris?.normal}
-                            alt={`${product.name} card`}
+                        src={src}
+                        alt={`Card`}
                             loading="lazy"
                         />
                         // </Link>
-                    )
+                    // )
                 }
             </div>
         </figure>

--- a/src/features/search/components/Print.js
+++ b/src/features/search/components/Print.js
@@ -45,7 +45,13 @@ const Print = ({ print }) => {
     // }, [response]);
     return (
         <div className='flex print'>
-            <Image classList={'print-image'} product={print} />
+            <Image classList={'print-image'} src={print.image_uris?.small || print.card_faces[0].image_uris?.small} />
+            {/* <img
+                className='print-image'
+                src={print.image_uris.small}
+                alt={`${print.name} card`}
+                loading="lazy"
+            /> */}
             <div className='col-9 flex'>
                 {
                     print.finishes.map((finish, i) => {

--- a/src/features/search/components/Set.js
+++ b/src/features/search/components/Set.js
@@ -7,19 +7,22 @@ const Set = ({ set }) => {
     const [hasLoaded, setHasLoaded] = useState(false);
     const { cardSets } = useSearch();
 
-    console.log(cardSets[set.id])
+    // console.log(cardSets[set.id])
 
-    const [imagesLoaded] = useImageLoader(set.prints);
+    // const [imagesLoaded] = useImageLoader(set.prints);
+
+    // useEffect(() => {
+    //     if (imagesLoaded.length > 0) {
+    //         console.log(imagesLoaded)
+    //     }
+    // })
 
     return (
         <div className="set">
             <div className="set-header">
                 <h2>
                     {
-                        // imagesLoaded &&
                         <span className='set-icon' style={{ maskImage: `url(${cardSets[set.id]?.icon_svg_uri})`, WebkitMaskImage: `url(${cardSets[set.id]?.icon_svg_uri})` }}>
-
-                            {/* <img className='icon' src={`${cardSets[set.set]?.icon_svg_uri}`} style={{ fill: 'red' }} onload='SVGInject(this)' alt='Set icon' /> */}
                         </span>
                     }
                     <span className='set-name'>{cardSets[set.id]?.name}</span>

--- a/src/hooks/useImageLoader.js
+++ b/src/hooks/useImageLoader.js
@@ -4,43 +4,45 @@
 
 import { useState, useEffect } from 'react';
 
-const useImageLoader = (cards) => {
+const useImageLoader = () => {
     const [imagesLoaded, setImagesLoaded] = useState(false);
-    const [urls, setUrls] = useState(null)
+    const [uris, setUris] = useState(null);
 
-    // Set urls array from cards array
-    useEffect(() => {
-        if (cards?.length) {
-            if (!urls) {
-                let imgUrls = []
-                cards.forEach(card => {
-                    if (card.image_uris) {
-                        imgUrls.push(card.image_uris?.normal);
-                    }
-                    else if (card.card_faces) {
-                        card.card_faces.forEach(card_face => {
-                            imgUrls.push(card_face.image_uris?.normal);
-                        })
-                    }
-                })
-                setUrls(imgUrls);
-            }
-        }
-    }, [cards])
+    // Set uris array from cards array
+    // useEffect(() => {
+    //     if (loadImages.length > 0) {
+    //     // if (!uris) {
+    //             let imguris = []
+    //         loadImages.forEach(el => {
+    //             if (el.image_uris) {
+    //                 imguris.push(el.image_uris?.normal);
+    //                 }
+    //             else if (el.card_faces) {
+    //                 el.card_faces.forEach(card_face => {
+    //                         imguris.push(card_face.image_uris?.normal);
+    //                     })
+    //                 }
+    //             })
+    //         // console.log(imguris)
+    //             seturis(imguris);
+    //         // }
+    //     }
+    // }, [loadImages])
 
-    // Fetch & load images from urls array
+    // Fetch & load images from uris array
     useEffect(() => {
-        if (urls) {
+        if (uris) {
+        // console.log(uris)
         const loadImage = url => {
             return new Promise((resolve, reject) => {
                 const image = new Image();
                 image.src = url;
                 image.alt = 'Magic Card Image'
-                image.onload = () => resolve(url);
+                image.onload = () => resolve(image);
                 image.onerror = error => reject(error);
             });
         }
-        Promise.all(urls.map(url => loadImage(url)))
+            Promise.all(uris.map(url => loadImage(url)))
             .then((data) => {
                 if (data) {
                     setImagesLoaded(true);
@@ -48,9 +50,9 @@ const useImageLoader = (cards) => {
             })
             .catch(error => console.log('Image load has failed', error))
         }
-    }, [urls])
+    }, [uris])
 
-    return [imagesLoaded]
+    return { imagesLoaded, setUris }
 }
 
 export default useImageLoader

--- a/src/hooks/useLazyLoader.js
+++ b/src/hooks/useLazyLoader.js
@@ -1,14 +1,17 @@
 import { useState, useEffect } from 'react';
 
-const useLazyLoader = (product) => {
+const useLazyLoader = (src) => {
     const [hasLoaded, setHasLoaded] = useState(false);
     useEffect(() => {
-        const img = new Image();
-        img.src = product?.image_uris?.normal || product?.card_faces[0]?.image_uris?.normal;
-        img.onload = () => {
-            setHasLoaded(true);
+        if (src) {
+
+            const img = new Image();
+            img.src = <source media="(min-width: )" srcset="" />;
+            img.onload = () => {
+                setHasLoaded(true);
+            }
         }
-    }, [product]);
+    }, [src]);
 
     return { hasLoaded }
 }

--- a/src/hooks/useResult.js
+++ b/src/hooks/useResult.js
@@ -6,11 +6,12 @@ import useSlideView from './useSlideView';
 import useCollectionModal from './useCollectionModal';
 
 const useResult = (search) => {
-    const [searchResult, setSearchResult] = useState([]);
-
-    const [imagesLoaded] = useImageLoader(search?.result);
+    const [results, setResults] = useState([]);
+    const [searchResults, setSearchResults] = useState(null);
 
     const [view, updateSlideView] = useSlideView(handleSlideView);
+
+    const { imagesLoaded, setUris } = useImageLoader()
 
     const [state, updateCollectionItem] = useCollectionModal(search?.type, handleCollectionItem);
 
@@ -26,19 +27,50 @@ const useResult = (search) => {
         updateCollectionItem(e.target.id, card, expandedImage);
     }
 
+    const getImgUris = (args) => {
+        const { results, type } = args;
+        console.log(results)
+        if (type === 'archive') {
+            const print_uris = results.map((result) => result.prints)
+                .flat()
+                .map(print => print.image_uris ? print.image_uris.normal : print.card_face.image_uris.normal)
+            // console.log(prints)
+            const icon_uris = results.map((result) => cardSets[result.id]?.icon_svg_uri)
+
+            return [...print_uris, ...icon_uris]
+        }
+        else {
+            return []
+        }
+    }
+
     useEffect(() => {
         if (search) {
             console.log(search)
-            const { query, result, type } = search;
+            const uris = getImgUris(search);
+            console.log(uris)
+            setUris(uris);
+        }
+    }, [search])
+
+    // useEffect(() => {
+    //     if (search) {
+    //         setSearchResults({...search});
+    //     }
+    // }, [search]);
+
+    useEffect(() => {
+        if (imagesLoaded) {
+            const { type, results } = search; 
             switch (type) {
                 case 'archive':
-                    handleArchive(query, result);
+                    setResults(results.map((set, i) => <Set key={i} set={set} />))
                     break;
                 case 'catalog':
-                    handleCatalog(query, result);
+                    handleCatalog(results);
                     break;
                 case 'collection':
-                    handleCollection(query, result);
+                    handleCollection(results);
                     break;
 
                 default:
@@ -46,19 +78,17 @@ const useResult = (search) => {
                     break;
             }
         }
-    }, [search]);
+    }, [imagesLoaded])
 
-    function handleArchive(query, result) {
-
-        console.log(result)
-
-        setSearchResult(result.map((set, i) => <Set key={i} set={set} />))
-
-    }
+    // function handleArchive(result) {
+    //     const products = result.map(res => res.prints).flat();
+    //     // console.log(products)
+    //     setLoadImages(products)
+    // }
     function handleCatalog(query, result) { }
     function handleCollection(query, result) { }
 
-    return { imagesLoaded, searchResult, state, view }
+    return { results, state, view }
 }
 
 export default useResult

--- a/src/hooks/useSearchForm.js
+++ b/src/hooks/useSearchForm.js
@@ -203,7 +203,7 @@ const useSearchForm = (inputRef) => {
                 inputRef?.current?.blur();
                 console.log(data)
                 // localStorage.setItem('search-results', JSON.stringify({ ...data }));
-                navigate(path, { state: { result: data, query, type } });
+                navigate(path, { state: { results: data, query, type } });
             }
 
         }

--- a/src/pages/public/SearchResults.js
+++ b/src/pages/public/SearchResults.js
@@ -29,7 +29,7 @@ const SearchResults = () => {
 
     // const [state, updateCollectionItem] = useCollectionModal(search?.type, handleCollectionItem);
 
-    const { searchResult, state, view, imagesLoaded } = useResult(search);
+    const { results, state, view } = useResult(search);
 
     useEffect(() => {
         console.log(location.state)
@@ -94,10 +94,9 @@ const SearchResults = () => {
                     {state.component}
                 </Modal>
             }
-            {imagesLoaded &&
                 <Page
                     name={'search-results'}
-                    title={search.query}
+                title={search?.query}
                 >
                     <SearchParameters
                         setSearchFeatures={(value) => setSearchFeatures(value)}
@@ -106,8 +105,8 @@ const SearchResults = () => {
 
                     <div className="list">
                         {
-                            searchResult &&
-                            searchResult.map((result, i) => {
+                        results &&
+                        results.map((result, i) => {
                                 return (
                                     result
                                     // <Card
@@ -150,7 +149,7 @@ const SearchResults = () => {
                             })
                         }
                     </div>
-                </Page>}
+            </Page>
         </>
     )
 }


### PR DESCRIPTION
Reduced font size of h2 set name. 
Uncommented min height of set header to 3.5rem.
Removed padding block to set header h2,
Removed Page component 1rem padding inline.
Reduced breadcrumbs padding inline from 2rem to 1rem.
Removed padding padding (inline and block) from page-header selector.
Replace naming convention from 'collection' to  'set' @useResult hook & Set component. 

Refactored useImageLoader and useResult hooks. 



Goals: 
Fitting longer set names inside set headers h2. 
Improving image and svg icons loading.
