### PR TITLE
Removed set header h2 padding block, left 1rem padding inline

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -1,25 +1,25 @@
 import useLazyLoader from '../hooks/useLazyLoader';
 
 const Image = ({ classList, src }) => {
-// const { hasLoaded } = useLazyLoader(src);
+    const { hasLoaded } = useLazyLoader(src);
 
     return (
         <figure className='product-view'>
             <div className={`product-view-container`}>
                 {/* <div className={`product-view-container ${product.finishes?.includes('foil') && 'is-foil'}`}> */}
                 {
-                    // !hasLoaded ? (
-                    //     <img src={require('../assets/img/mtg_card_back.jpg')} alt='Magic back card' />
-                    // ) : (
+                    !hasLoaded ? (
+                        <img src={require('../assets/img/mtg_card_back.jpg')} alt='Magic back card' />
+                    ) : (
                         // <Link to={`/product/${product.name}`}>
                         <img
                             className={classList}
-                        src={src}
-                        alt={`Card`}
+                                src={src}
+                                alt={`Card`}
                             loading="lazy"
                         />
                         // </Link>
-                    // )
+                        )
                 }
             </div>
         </figure>


### PR DESCRIPTION
Reduced font size of h2 set name. 
Uncommented min height of set header to 3.5rem.
Removed padding block to set header h2,
Removed Page component 1rem padding inline.
Reduced breadcrumbs padding inline from 2rem to 1rem.
Removed padding padding (inline and block) from page-header selector.
Replace naming convention from 'collection' to  'set' @useResult hook & Set component. 

Refactored useImageLoader and useResult hooks. 
Uncommented useLazyLoader hook @ Image component.


Goals: 
Fitting longer set names inside set headers h2. 
Improving image and svg icons loading.
