### PR TITLE
Fixed data persistence on page reload @ SearchResults

### DIFF
--- a/src/contexts/SearchContext.js
+++ b/src/contexts/SearchContext.js
@@ -10,7 +10,6 @@ const initialState = {
   inputValue: '',
   position: -200,
   predictions: [],
-  results: [],
   searchTerm: '',
   searchType: '',
   selection: '',
@@ -29,13 +28,13 @@ export const SearchProvider = ({ children }) => {
     inputValue,
     position,
     predictions,
-    results,
     searchTerm,
     searchType,
     selection,
     tracker,
   } = state || {};
 
+  const [results, setResults] = useState(null)
   const [cardSets, setCardSets] = useState(null);
   const [cardCollection, setCardCollection] = useState([]);
   const [archiveCardNames, setArchiveCardNames] = useState(null);
@@ -70,7 +69,7 @@ export const SearchProvider = ({ children }) => {
       // Fetch card sets array of objects
       fetch(url, config);
     }
-  }, [])
+  }, []);
 
   useEffect(() => {
     if (response) {
@@ -79,7 +78,14 @@ export const SearchProvider = ({ children }) => {
       // console.log(sets)
       setCardSets(sets);
     }
-  }, [response])
+  }, [response]);
+
+  // useEffect(() => {
+  //   if (results) {
+  //     console.log(results);
+  //     localStorage.setItem('search-results', JSON.stringify(results));
+  //   }
+  // }, [results])
 
   // Returns array of unique card names
   const filterCardNames = (cards) => {
@@ -107,6 +113,8 @@ export const SearchProvider = ({ children }) => {
         setCardCollection,
         isCollectionEmpty,
         setIsCollectionEmpty,
+        results,
+        setResults,
         cardSets,
         setCardSets,
         archiveCardNames,
@@ -132,7 +140,6 @@ export const SearchProvider = ({ children }) => {
         inputValue,
         position,
         predictions,
-        results,
         searchType,
         searchTerm,
         selection,

--- a/src/features/search/SearchForm.js
+++ b/src/features/search/SearchForm.js
@@ -68,7 +68,7 @@ const SearchForm = ({ children, classList, type, placeholder, cardNames, inputRe
 
     const handleFocus = (e) => {
         setIsActive(true);
-        handleSetSearch(cardNames, e.target.id);
+        handleSetSearch(e, cardNames);
     }
 
     useEffect(() => {

--- a/src/features/search/components/Print.js
+++ b/src/features/search/components/Print.js
@@ -17,7 +17,7 @@ const Print = ({ print, ModalImage }) => {
         error,
         isAdded,
     } = useResponseHandler();
-    console.log(ModalImage)
+    // console.log(ModalImage)
 
     const { auth } = useAuth();
 

--- a/src/features/search/components/Set.js
+++ b/src/features/search/components/Set.js
@@ -10,35 +10,33 @@ const Set = ({ set }) => {
 
     useEffect(() => {
         setUris(set.prints.map(print => print?.image_uris ? print?.image_uris.normal : print?.card_faces[0].image_uris.normal))
-    }, [])
-
-
-    // ModalImage={() => {
-    //     const { alt, ...rest } = images[i].props;
-    //     return <img {...rest} alt={alt} />
-    // }} />))
+    }, []);
 
     return (
-        <div className="set">
-            <div className="set-header">
-                <h2>
-                    <span
-                        className='set-icon' 
-                        style={{ maskImage: `url(${cardSets[set.id]?.icon_svg_uri})`, WebkitMaskImage: `url(${cardSets[set.id]?.icon_svg_uri})` }}
-                    >
-                    </span>
-                    <span className='set-name'>{cardSets[set.id]?.name}</span>
-                </h2>
-            </div>
-            <div className='set-prints'>
-                {
-                    images &&
-                    set?.prints.map((print, i) => {
-                        return <Print key={i} print={print} ModalImage={() => <img {...images[i].props} alt={images[i].props.alt} />} />
-                    })
-                }
-            </div>
-        </div>
+        <>
+            {cardSets && 
+                <div className="set">
+                    <div className="set-header">
+                        <h2>
+                            <span
+                                className='set-icon'
+                                style={{ maskImage: `url(${cardSets[set.id]?.icon_svg_uri})`, WebkitMaskImage: `url(${cardSets[set.id]?.icon_svg_uri})` }}
+                            >
+                            </span>
+                            <span className='set-name'>{cardSets[set.id]?.name}</span>
+                        </h2>
+                    </div>
+                    <div className='set-prints'>
+                        {
+                            images &&
+                            set?.prints.map((print, i) => {
+                                return <Print key={i} print={print} ModalImage={() => <img {...images[i].props} alt={images[i].props.alt} />} />
+                            })
+                        }
+                    </div>
+                </div>
+            }
+        </>
     )
 }
 

--- a/src/features/search/services/searchReducer.js
+++ b/src/features/search/services/searchReducer.js
@@ -25,11 +25,6 @@ export const searchReducer = (state, action) => {
                 inputValue: action.payload.term,
                 exact: action.payload.exact
             }
-        case 'results':
-            return {
-                ...state,
-                results: action.payload
-            }
         case 'set-search':
             return {
                 ...state,

--- a/src/hooks/useResults.js
+++ b/src/hooks/useResults.js
@@ -1,17 +1,19 @@
 import { useState, useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
 import Set from '../features/search/components/Set';
 import useCollectionModal from './useCollectionModal';
 import useSlideView from './useSlideView';
+import useSearch from './contexthooks/useSearch';
 import useImageLoader from './useImageLoader';
 
-const useResults = () => {
-    const [searchResults, setSearchResults] = useState(null);
-
+const useResults = (inputRef) => {
+    const navigate = useNavigate();
+    const location = useLocation();
     // const [view, updateSlideView] = useSlideView(handleSlideView);
 
     // const [state, updateCollectionItem] = useCollectionModal(search?.type, handleCollectionItem);
 
-    const { images, setUris } = useImageLoader();
+    const { setResults } = useSearch();
 
     // function handleSlideView(e, layout, expandedImage) {
     //     e.stopPropagation();
@@ -23,11 +25,12 @@ const useResults = () => {
     //     updateCollectionItem(e.target.id, card, expandedImage);
     // }
 
-    const handleSearchResults = (data, type) => {
-        // const { type, searchResults } = search;
+
+    const handleSearchResults = (data, props) => {
+        const { path, query, type } = props;
         switch (type) {
             case 'archive':
-                setSearchResults(data.map((set, i) => <Set key={i} set={set} />))
+                setResults(data.map((set, i) => <Set key={i} set={set} />))
                 break;
             case 'catalog':
                 handleCatalog(data);
@@ -40,12 +43,14 @@ const useResults = () => {
                 console.log('unknown search')
                 break;
         }
+        localStorage.setItem('search-results', JSON.stringify({ data: data, props: props }))
+        navigate(path, { state: { query: query } });
     }
 
     function handleCatalog(query, result) { }
     function handleCollection(query, result) { }
 
-    return { searchResults, handleSearchResults }
+    return { handleSearchResults }
 }
 
 export default useResults

--- a/src/layout/Breadcrumbs.js
+++ b/src/layout/Breadcrumbs.js
@@ -5,7 +5,7 @@ import capitalizeString from '../assets/utilities/capitalizeString';
 
 const Breadcrumbs = () => {
     const location = useLocation();
-    const path = location.pathname;
+    const path = decodeURI(location.pathname);
     ////////////////////////////////////////
     // Exclude breadcrumbs 
     // @ catalog search results / 
@@ -25,7 +25,9 @@ const Breadcrumbs = () => {
     let currentLink = ''
 
     const crumbs = path.split('/')
-        .filter(crumb => crumb !== '')
+        .filter(crumb => {
+            return crumb !== ''
+        })
         .map((crumb, i) => {
             currentLink += `/${crumb}`;
             return (

--- a/src/pages/public/SearchResults.js
+++ b/src/pages/public/SearchResults.js
@@ -12,8 +12,9 @@ import SearchParameters from '../../features/search/components/SearchParameters'
 import useCollectionModal from '../../hooks/useCollectionModal';
 import useSlideView from '../../hooks/useSlideView';
 import useImageLoader from '../../hooks/useImageLoader';
-// import useResult from '../../hooks/useResult';
+import useResults from '../../hooks/useResults';
 import useSearch from '../../hooks/contexthooks/useSearch';
+import useSearchForm from '../../hooks/useSearchForm';
 
 const SearchResults = () => {
     // States
@@ -24,6 +25,18 @@ const SearchResults = () => {
     const navigate = useNavigate();
 
     const { results } = useSearch();
+    const { handleSearchResults } = useResults();
+
+    useEffect(() => {
+        if (!results && localStorage.getItem('search-results')) {
+            const { data, props } = JSON.parse(localStorage.getItem('search-results'))
+            handleSearchResults(data, props);
+        }
+    }, [])
+
+    // useEffect(() => {
+    //     console.log(results)
+    // }, [results])
 
     // const [imagesLoaded] = useImageLoader(search?.data);
 
@@ -32,8 +45,6 @@ const SearchResults = () => {
     // const [state, updateCollectionItem] = useCollectionModal(search?.type, handleCollectionItem);
 
     // const { results } = useResult(search);
-
-
 
     // useEffect(() => {
     //     if (url && config) {
@@ -96,8 +107,7 @@ const SearchResults = () => {
 
                     <div className="list">
                         {
-                        results &&
-                        results.map((result, i) => {
+                        results?.map((result, i) => {
                                 return (
                                     result
                                     // <Card


### PR DESCRIPTION
Search tasks divided between useSearchForm and useResults custom hooks.
useSearchForm fetches and format data befor calling handleSearchResults method @ useResults.

handleSearchResults takes two arguments: the processed data and a props object with path, query and type keys.
The method sets the proper array of components to be rendered according to the [search] type provided [archive, catatalog, collection...]. It does so by updating the results state @ SearchContext.
Finally, it saves the data in localStorage and navigates to search results view [SearchResults]. 

On every render, SearchResults component checks if results state is defined. If not it calls handleSearchResults with localStorage 'search-results' object.
