### PR TITLE
Implemented new modal logic

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -1,30 +1,25 @@
 import useLazyLoader from '../hooks/useLazyLoader';
-import useModal from '../hooks/useModal';
+import useModalContext from '../hooks/contexthooks/useModalContext';
 
-const Image = ({ classList, src, index }) => {
+const Image = ({ classList, index, src, layout }) => {
     const { hasLoaded } = useLazyLoader(src);
-    const { handleSetModal } = useModal();
+    const { handleModalProps } = useModalContext();
+
     return (
         
         <figure className='product-view'>
            { !hasLoaded ? (
                 <img className='print-radius' src={require('../assets/img/mtg_card_back.jpg')} alt='Magic back card' />
             ) : (
-                // <Link to={`/product/${product.name}`}>
                 <img
                     className={classList}
                         src={src}
                         alt={`Card`}
-                        onClick={() => handleSetModal({ type: 'slide', content: index })}
+                        onClick={() => handleModalProps({ type: 'slide', index: index, layout: layout })}
                     loading="lazy"
-                />
-                // </Link>
+                    />
                 )}
         </figure>
-            // <div className={`product-view-container`}>
-                //  <div className={`product-view-container ${product.finishes?.includes('foil') && 'is-foil'}`}> 
-                // 
-        //     </div>
     )
 }
 

--- a/src/contexts/ModalContext.js
+++ b/src/contexts/ModalContext.js
@@ -5,12 +5,9 @@ import { modalReducer } from '../features/modal/services/modalReducer';
 const initialState = {
     content: null,
     open: false,
-    type: '',
+    props: null,
     uris: null
 }
-
-// Modal type: slide, carrousel, form
-
 
 export const ModalContext = createContext(null);
 
@@ -21,7 +18,7 @@ export const ModalProvider = ({ children }) => {
     const {
         content,
         open,
-        type,
+        props,
         uris,
     } = state || {}
 
@@ -31,18 +28,51 @@ export const ModalProvider = ({ children }) => {
         if (uris) {
             loadImages(uris);
         }
-    }, [uris])
+    }, [uris]);
 
+    function handleModalUris(uris) {
+        dispatch({
+            type: 'set-uris',
+            payload: uris,
+        })
+    }
+
+    function handleOpenModal(open) {
+        dispatch({
+            type: 'open-modal',
+            payload: open
+        })
+    }
+
+    function handleModalProps(props) {
+        // console.log(props)
+        dispatch({
+            type: 'set-props',
+            payload: props
+        })
+    }
+
+    function handleModalContent(content) {
+        dispatch({
+            type: 'set-content',
+            payload: content
+        })
+    }
 
     return (
         <ModalContext.Provider
             value={{
+                images,
+
                 content,
                 open,
-                type,
+                props,
                 uris,
-                dispatch,
-                initialState
+
+                handleModalContent,
+                handleModalProps,
+                handleModalUris,
+                handleOpenModal
             }}
         >
             {children}

--- a/src/features/modal/components/Slide.js
+++ b/src/features/modal/components/Slide.js
@@ -1,0 +1,16 @@
+import CloseBtn from '../buttons/CloseBtn';
+import useModalContext from '../../../hooks/contexthooks/useModalContext';
+
+const Slide = ({ children }) => {
+    const { handleOpenModal } = useModalContext();
+    return (
+        <div className={"slide-view"}>
+            <div className={"modal-frame"}>
+                <CloseBtn classList={`slide-close-btn close-btn card-btn`} name={'close-btn'} handleClick={() => handleOpenModal(false)} />
+            </div>
+            {children}
+        </div>
+    )
+}
+
+export default Slide

--- a/src/features/modal/services/modalReducer.js
+++ b/src/features/modal/services/modalReducer.js
@@ -1,41 +1,26 @@
-///////////////////////////////////////////////////////////////////////
-//    Updates search input & prediction list @ SearchForm            //
-//    Tracks mouse events & updates tracker position @ Autocomplete  //
-///////////////////////////////////////////////////////////////////////
 export const modalReducer = (state, action) => {
     switch (action.type) {
-        case 'open':
+        case 'open-modal':
             return {
                 ...state,
                 open: action.payload
-            }
-        case 'set-type':
-            return {
-                ...state,
-                type: action.payload,
-            }
-        case 'set-modal':
-            return {
-                ...state,
-                set: action.payload
-            }
-        case 'set-uris':
-            return {
-                ...state,
-                uris: action.payload
             }
         case 'set-content':
             return {
                 ...state,
                 content: action.payload
             }
-        case 'clear-modal':
+        case 'set-props':
             return {
-                ...action.payload
+                ...state,
+                props: action.payload
+            }
+        case 'set-uris':
+            return {
+                ...state,
+                uris: action.payload
             }
         default:
-            return {
-                ...state
-            }
+            return null;
     }
 }

--- a/src/features/search/components/Print.js
+++ b/src/features/search/components/Print.js
@@ -5,6 +5,8 @@ import useAuthContext from '../../../hooks/contexthooks/useAuthContext';
 import useFind from '../../../hooks/useFind';
 import useResponseHandler from '../../../hooks/useResponseHandler';
 
+import useModalContext from '../../../hooks/contexthooks/useModalContext';
+
 const Print = ({ index, print }) => {
     const {
         handleGetResponse,
@@ -20,6 +22,7 @@ const Print = ({ index, print }) => {
 
     const { auth } = useAuthContext();
 
+    const { uris } = useModalContext();
     // const { findMatch, isMatchFound } = useFind();
 
     // useEffect(() => {
@@ -45,7 +48,13 @@ const Print = ({ index, print }) => {
     // }, [response]);
     return (
         <div className='flex print'>
-            <Image classList={'image-print'} src={print.image_uris?.small || print.card_faces[0].image_uris?.small} index={index} />
+            <Image
+                classList={'image-print'}
+                // Set index reference 
+                index={uris.findIndex(uri => uri === print.image_uris.normal)}
+                src={print.image_uris?.small || print.card_faces[0].image_uris?.small}
+                layout={print.layout}
+            />
             <div className='finishes'>
                 {
                     print.finishes.map((finish, i) => {

--- a/src/features/search/components/Set.js
+++ b/src/features/search/components/Set.js
@@ -1,18 +1,9 @@
-import { useEffect } from 'react';
 import Print from './Print';
-// import useLoadImages from '../../../hooks/useLoadImages';
 import useSearchContext from '../../../hooks/contexthooks/useSearchContext';
-import useModal from '../../../hooks/useModal';
 
-const Set = ({ set }) => {
+const Set = ({ id, prints }) => {
 
     const { cardSets } = useSearchContext();
-
-    const { handleModalImageUris } = useModal();
-
-    useEffect(() => {
-        handleModalImageUris(set.prints.map(print => print?.image_uris ? print?.image_uris.normal : print?.card_faces[0].image_uris.normal))
-    }, []);
 
     return (
         <>
@@ -22,15 +13,15 @@ const Set = ({ set }) => {
                         <h2>
                             <span
                                 className='set-icon'
-                                style={{ maskImage: `url(${cardSets[set.id]?.icon_svg_uri})`, WebkitMaskImage: `url(${cardSets[set.id]?.icon_svg_uri})` }}
+                                style={{ maskImage: `url(${cardSets[id]?.icon_svg_uri})`, WebkitMaskImage: `url(${cardSets[id]?.icon_svg_uri})` }}
                             >
                             </span>
-                            <span className='set-name'>{cardSets[set.id]?.name}</span>
+                            <span className='set-name'>{cardSets[id]?.name}</span>
                         </h2>
                     </div>
                     <div className='set-prints'>
                         {
-                            set?.prints.map((print, i) => {
+                            prints.map((print, i) => {
                                 return <Print key={i} index={i} print={print} />
                             })
                         }

--- a/src/features/search/services/searchReducer.js
+++ b/src/features/search/services/searchReducer.js
@@ -48,8 +48,6 @@ export const searchReducer = (state, action) => {
                 ...action.payload
             }
         default:
-            return {
-                ...state
-            }
+            return null;
     }
 }

--- a/src/hooks/useModal.js
+++ b/src/hooks/useModal.js
@@ -1,58 +1,45 @@
-// import { useState, useEffect } from 'react'
-import useModalContext from './contexthooks/useModalContext'
+import { useEffect } from 'react';
+import useModalForm from './useModalForm';
+import useModalSlide from './useModalSlide';
+import useModalSlideShow from './useModalSlideShow';
+import useModalContext from './contexthooks/useModalContext';
 
 const useModal = () => {
+    const { content, open, props, handleOpenModal } = useModalContext()
 
-    const {
-        dispatch,
-        initialState
-    } = useModalContext();
+    const { setModalForm } = useModalForm();
+    const { setModalSlide } = useModalSlide();
+    const { setModalSlideShow } = useModalSlideShow();
 
-    const handleSetModal = (type, content) => {
-        dispatch({
-            type: 'set-modal',
-            payload: {
-                type: type,
-                content: content
+    useEffect(() => {
+        if (props) {
+            const { type, ...rest } = props;
+            switch (type) {
+                case 'form':
+                    setModalForm(rest)
+                    break;
+                case 'slide':
+                    setModalSlide(rest)
+                    break;
+                case 'slide-show':
+                    setModalSlideShow(rest)
+                    break;
+
+                default:
+                    break;
             }
-        })
-    }
+        }
+    }, [props]);
 
-    const handleModalImageUris = (uris) => {
-        dispatch({
-            type: 'set-uris',
-            payload: uris
-        })
-    }
+    useEffect(() => {
+        // console.log(content)
+        // Open modal if content is set
+        if (content) {
+            handleOpenModal(true);
+        }
+    }, [content])
 
-    const handleOpenModal = (bool) => {
-        dispatch({
-            type: 'open',
-            payload: bool
-        })
-    }
-
-    // const handleModalContent = (content) => {
-    //     dispatch({
-    //         type: 'set-content',
-    //         content: content
-    //     })
-    // }
-
-    const handleClearModal = () => {
-        dispatch({
-            type: 'clear-modal',
-            payload: initialState
-        })
-    }
-
-    return {
-        handleSetModal,
-        handleOpenModal,
-        handleModalImageUris,
-        // handleModalContent,
-        handleClearModal
-    }
+    return { open, content }
 }
 
 export default useModal

--- a/src/hooks/useModalForm.js
+++ b/src/hooks/useModalForm.js
@@ -1,4 +1,4 @@
-import { useEffect, useReducer, useRef } from 'react';
+import { useState, useEffect, useReducer, useRef } from 'react';
 import { storeItemReducer } from '../features/product/services/storeItemReducer';
 import { deckItemReducer } from '../features/product/services/deckItemReducer';
 import useAxios from './useAxios';
@@ -25,44 +25,45 @@ const initialState = {
 }
 
 const useModalForm = (product) => {
+    const [modalForm, setModalForm] = useState(null);
     const [state, dispatch] = useReducer(storeItemReducer, initialState);
 
     const { auth } = useAuthContext();
 
     const { post, patch, error, loading, response } = useAxios();
 
-    useEffect(() => {
-        console.log(product)
-        // Product already exists. 
-        // Set state values.
-        if (product.catalogId) {
-            dispatch({
-                type: 'set-form',
-                payload: { ...product }
-            })
-        }
-        else {
-            // Set isNewProduct state to true.
-            // Set reference to product id.
-            // Set catalogId
-            handleNewProduct(true, product.card_id, product.name);
-        }
-    }, [product])
+    // useEffect(() => {
+    //     console.log(product)
+    //     // Product already exists. 
+    //     // Set state values.
+    //     if (product.catalogId) {
+    //         dispatch({
+    //             type: 'set-form',
+    //             payload: { ...product }
+    //         })
+    //     }
+    //     else {
+    //         // Set isNewProduct state to true.
+    //         // Set reference to product id.
+    //         // Set catalogId
+    //         handleNewProduct(true, product.card_id, product.name);
+    //     }
+    // }, [product])
 
-    useEffect(() => {
-        if (state.isValid) {
-            // Remove unnecessary props
-            const { isSubmit, isUpdated, isValid, isNewProduct, ...rest } = state;
-            if (state.isNewProduct) {
-                console.log('new product')
-                post(auth.token, `/api/users/store/${auth.user.id}`, rest);
-            }
-            else {
-                console.log('existing product')
-                patch(auth.token, `/api/users/store/${auth.user.id}/${rest.catalogId}`, rest);
-            }
-        }
-    }, [state.isValid])
+    // useEffect(() => {
+    //     if (state.isValid) {
+    //         // Remove unnecessary props
+    //         const { isSubmit, isUpdated, isValid, isNewProduct, ...rest } = state;
+    //         if (state.isNewProduct) {
+    //             console.log('new product')
+    //             post(auth.token, `/api/users/store/${auth.user.id}`, rest);
+    //         }
+    //         else {
+    //             console.log('existing product')
+    //             patch(auth.token, `/api/users/store/${auth.user.id}/${rest.catalogId}`, rest);
+    //         }
+    //     }
+    // }, [state.isValid])
 
     const btnRef = useRef(null);
 
@@ -143,6 +144,7 @@ const useModalForm = (product) => {
     }
 
     return {
+        setModalForm,
         handlePrice,
         handleQuantity,
         handleCondition,

--- a/src/hooks/useModalSlide.js
+++ b/src/hooks/useModalSlide.js
@@ -1,0 +1,85 @@
+import { useState, useEffect, useReducer } from 'react'
+import useModalContext from './contexthooks/useModalContext';
+import Slide from '../features/modal/components/Slide';
+const initialState = {
+  slide: null,
+}
+const useModalSlide = () => {
+  const [modalSlide, setModalSlide] = useState(null);
+  const { images, handleModalContent } = useModalContext();
+
+  // const [state, dispatch] = useReducer(slideReducer, initialState)
+
+  // const slideReducer = () => {
+
+  // }
+
+  function handleFlip(image) {
+    // dispatch({
+    //   type: 'single-slide',
+    //   slide: image
+    // });
+    console.log('flip', image);
+  }
+
+  function handleSplit(image) {
+    console.log('split', image)
+  }
+
+  function handleReversible(image) {
+    console.log('reversible', image)
+  }
+
+  function handleNormal(image) {
+    console.log('normal', image)
+    handleModalContent(<Slide>{image}</Slide>)
+  }
+
+  useEffect(() => {
+    if (modalSlide) {
+      // console.log(modalSlide)
+      const { layout, index } = modalSlide;
+      switch (layout) {
+        case 'flip':
+          handleFlip(images[index]);
+          break;
+        case 'split':
+        case 'planar':
+          handleSplit(images[index]);
+          break;
+        case 'transform':
+        case 'modal_dfc':
+        case 'reversible_card':
+        case 'double_faced_token':
+        case 'art_series':
+          handleReversible(images[index]);
+          break;
+        case 'normal':
+        case 'leveler':
+        case 'class':
+        case 'saga':
+        case 'meld':
+        case 'adventure':
+        case 'mutate':
+        case 'prototype':
+        case 'scheme':
+        case 'token':
+        case 'emblem':
+        case 'augment':
+        case 'host':
+        case 'vanguard':
+          handleNormal(images[index]);
+          break;
+        default:
+          // dispatch({
+          //   type: null,
+          // })
+          break;
+      }
+    }
+  }, [modalSlide])
+
+  return { setModalSlide }
+}
+
+export default useModalSlide

--- a/src/hooks/useModalSlideShow.js
+++ b/src/hooks/useModalSlideShow.js
@@ -1,0 +1,23 @@
+import { useState, useEffect } from 'react'
+
+const useModalSlideShow = () => {
+    const [modalSlideShow, setModalSlideShow] = useState(null);
+
+    useEffect(() => {
+        if (modalSlideShow) {
+            const { layout, index } = modalSlideShow;
+            switch (layout) {
+                case '':
+
+                    break;
+
+                default:
+                    break;
+            }
+        }
+    }, [modalSlideShow])
+
+    return { setModalSlideShow }
+}
+
+export default useModalSlideShow

--- a/src/hooks/useResults.js
+++ b/src/hooks/useResults.js
@@ -5,6 +5,7 @@ import useCollectionModal from './useCollectionModal';
 import useSlideView from './useSlideView';
 import useSearchContext from './contexthooks/useSearchContext';
 import useLoadImages from './useLoadImages';
+import useModalContext from './contexthooks/useModalContext';
 
 const useResults = (inputRef) => {
     const navigate = useNavigate();
@@ -14,6 +15,7 @@ const useResults = (inputRef) => {
     // const [state, updateCollectionItem] = useCollectionModal(search?.type, handleCollectionItem);
 
     const { setResults } = useSearchContext();
+    const { handleModalUris } = useModalContext();
 
     // function handleSlideView(e, layout, expandedImage) {
     //     e.stopPropagation();
@@ -24,13 +26,37 @@ const useResults = (inputRef) => {
     //     e.stopPropagation();
     //     updateCollectionItem(e.target.id, card, expandedImage);
     // }
+    const handleArchive = (data) => {
 
+        const results = new Map([
+            [
+                'uris',
+                data.map(set => set.prints).flat()
+                    .map(print => print?.image_uris ?
+                        print?.image_uris.normal :
+                        print?.card_faces[0].image_uris.normal)
+            ],
+            [
+                'sets',
+                data.map((set, i) => <Set key={i} id={set.id} prints={set.prints} />)
+            ]
+        ]);
+    // console.log(results.get('uris'))
+    // console.log(results.get('sets'))
+
+        // Passing imgages uris to reducer function @ ModalContext,
+        // updates uris reducer state which triggers loadImages custom hook function @ useLoadImages.
+        // useLoadImages preloads and creates normal size images component modal ready if needed. 
+        handleModalUris(results.get('uris'));
+        setResults(results.get('sets'));
+    }
 
     const handleSearchResults = (data, props) => {
+        console.log(data)
         const { path, query, type } = props;
         switch (type) {
             case 'archive':
-                setResults(data.map((set, i) => <Set key={i} set={set} />))
+                handleArchive(data);
                 break;
             case 'catalog':
                 handleCatalog(data);

--- a/src/hooks/useSearchForm.js
+++ b/src/hooks/useSearchForm.js
@@ -90,7 +90,6 @@ const useSearchForm = (inputRef) => {
     }
 
     const setString = (str) => {
-        console.log(str)
         return str.toLowerCase()
             .replaceAll(/["/,]/g, '')
             .replace('  ', ' ')
@@ -153,7 +152,7 @@ const useSearchForm = (inputRef) => {
     // Removes digital cards
     // Modifies card objects with finish property or,
     // Generates new card object if finishes property has more than one value : [nonfoil, foil, etched]
-    // Returns new array
+    // Returns new array of card objects
     const handleResponse = (cards) => {
         // Source @ https://stackoverflow.com/questions/63787449/javascript-group-array-of-objects-by-common-values-with-label
         if (cards) {
@@ -208,6 +207,7 @@ const useSearchForm = (inputRef) => {
         if (error) {
             const { query } = fetchParams;
             navigate(`/not-found/${query.split(' ').join('+')}`);
+            inputRef?.current.blur();
         }
     }, [error, response]);
 

--- a/src/layout/RootLayout.js
+++ b/src/layout/RootLayout.js
@@ -4,14 +4,14 @@ import MainHeader from './MainHeader';
 import MainFooter from './MainFooter'
 import Modal from '../features/modal/Modal';
 import useAuthContext from '../hooks/contexthooks/useAuthContext';
-import useModalContext from '../hooks/contexthooks/useModalContext';
+import useModal from '../hooks/useModal';
 
 const RootLayout = () => {
     const location = useLocation();
     const path = location.pathname;
 
     const { isAuth } = useAuthContext();
-    const { open, content } = useModalContext();
+    const { open, content } = useModal();
 
     return (
         <div className={`root-layout ${isAuth || path === '/login' || path === '/signup' ? 'bg-light' : 'bg-night'}`}>
@@ -22,20 +22,16 @@ const RootLayout = () => {
                     <Outlet />
 
                 ) : (
-                        <>      
+                        <>   
                             {
-                                !open ?
-                                    <>
-                                        <MainHeader />
-                                        <Outlet />
-                                        <MainFooter />
-                                    </>
-                                    :
-                                    <Modal open={open}>
-                                        {content}
-                                    </Modal>
+                                <Modal open={open}>
+                                    {content}
+                                </Modal>
                             }
-                    </>
+                            <MainHeader />
+                            <Outlet />
+                            <MainFooter />                   
+                        </>
                 )
             }
         </div>


### PR DESCRIPTION
Implemented new modal handling architecture:
ModalContext with modalReducer and useModal custom hooks at its core.

useModal dispatches proper modal props according to modal type.
Modal type has three possible state: 'form', 'slide' and 'slide-show'. 
Each type is assigned its custom hook: useModalForm, useModalSlide and useModalSlideShow.
Each hook assigns the corresponding component to the modal 'content' reducer state. 

Slide has three possible state: 'flip', 'split', 'reversible' and 'normal'.

Note: Only tested with normal slides for the time being. More to come.