### PR TITLE
Moved  uris state @ ModalContext from reducer to setUris state

### DIFF
--- a/src/contexts/ModalContext.js
+++ b/src/contexts/ModalContext.js
@@ -1,4 +1,4 @@
-import { useEffect, useReducer, createContext } from 'react';
+import { useEffect, useState, useReducer, createContext } from 'react';
 import useLoadImages from '../hooks/useLoadImages';
 import { modalReducer } from '../features/modal/services/modalReducer';
 
@@ -6,20 +6,18 @@ const initialState = {
     content: null,
     open: false,
     props: null,
-    uris: null
 }
 
 export const ModalContext = createContext(null);
 
 export const ModalProvider = ({ children }) => {
-
+    const [uris, setUris] = useState(null);
     const [state, dispatch] = useReducer(modalReducer, initialState);
 
     const {
         content,
         open,
         props,
-        uris,
     } = state || {}
 
     const { loadImages, images } = useLoadImages();
@@ -30,17 +28,17 @@ export const ModalProvider = ({ children }) => {
         }
     }, [uris]);
 
-    function handleModalUris(uris) {
-        dispatch({
-            type: 'set-uris',
-            payload: uris,
-        })
-    }
-
     function handleOpenModal(open) {
         dispatch({
             type: 'open-modal',
             payload: open
+        })
+    }
+
+    function handleClearModal() {
+        dispatch({
+            type: 'clear-modal',
+            payload: initialState
         })
     }
 
@@ -68,10 +66,10 @@ export const ModalProvider = ({ children }) => {
                 open,
                 props,
                 uris,
-
+                setUris, 
                 setModalContent,
+                handleClearModal,
                 handleModalProps,
-                handleModalUris,
                 handleOpenModal
             }}
         >

--- a/src/features/modal/buttons/CloseBtn.js
+++ b/src/features/modal/buttons/CloseBtn.js
@@ -2,13 +2,13 @@ import useModalContext from '../../../hooks/contexthooks/useModalContext';
 import { FaXmark } from "react-icons/fa6";
 
 const CloseBtn = () => {
-    const { handleOpenModal } = useModalContext();
+    const { handleClearModal } = useModalContext();
     return (
         <button
             id='close-btn'
             className={`slide-close-btn slide-btn`}
             type="button"
-            onClick={() => handleOpenModal(false)}>
+            onClick={() => handleClearModal()}>
             <FaXmark />
         </button>
     )

--- a/src/features/modal/services/modalReducer.js
+++ b/src/features/modal/services/modalReducer.js
@@ -5,6 +5,10 @@ export const modalReducer = (state, action) => {
                 ...state,
                 open: action.payload
             }
+        case 'clear-modal':
+            return {
+                ...action.payload
+            }
         case 'set-content':
             return {
                 ...state,

--- a/src/hooks/useModal.js
+++ b/src/hooks/useModal.js
@@ -6,7 +6,14 @@ import useModalSlideShow from './useModalSlideShow';
 import useModalContext from './contexthooks/useModalContext';
 
 const useModal = () => {
-    const { content, open, props, handleOpenModal, setModalContent } = useModalContext()
+    const {
+        content,
+        open,
+        props,
+        setModalContent,
+        handleClearModal,
+        handleOpenModal,
+    } = useModalContext()
 
     const { setModalForm } = useModalForm();
     const { setModalSlideShow } = useModalSlideShow();
@@ -38,7 +45,7 @@ const useModal = () => {
         // [click event on browser's back or forward arrows]
         if (pathname && open) {
             // Close modal
-            handleOpenModal(false);
+            handleClearModal();
         }
     }, [pathname])
 

--- a/src/hooks/useModalFrame.js
+++ b/src/hooks/useModalFrame.js
@@ -9,12 +9,12 @@ const useModalFrame = () => {
     const frontRef = useRef(null);
     const btnRef = useRef(null);
 
-    const { handleOpenModal } = useModalContext();
+    const { handleClearModal } = useModalContext();
 
     const handlers = {
-        normal: [() => handleOpenModal(false)],
+        normal: [() => handleClearModal()],
         reversible: [
-            () => handleOpenModal(false),
+            () => handleClearModal(),
             () => {
                 cardRef.current?.classList.toggle('rotate-y-180');
                 frontRef.current?.classList.toggle('hide');
@@ -22,13 +22,13 @@ const useModalFrame = () => {
             }
         ],
         flip: [
-            () => handleOpenModal(false),
+            () => handleClearModal(),
             () => {
                 cardRef.current?.classList.toggle('rotate-180');
             }
         ],
         split: [
-            () => handleOpenModal(false),
+            () => handleClearModal(),
             () => {
                 cardRef.current?.classList.toggle('rotate-90');
             }

--- a/src/hooks/useResults.js
+++ b/src/hooks/useResults.js
@@ -7,7 +7,7 @@ const useResults = () => {
     const navigate = useNavigate();
 
     const { setResults } = useSearchContext();
-    const { handleModalUris } = useModalContext();
+    const { setUris } = useModalContext();
 
     const handleArchive = (data) => {
         const results = new Map([
@@ -27,7 +27,7 @@ const useResults = () => {
         // Passing imgages uris to reducer function @ ModalContext,
         // updates uris reducer state which triggers loadImages custom hook function @ useLoadImages.
         // useLoadImages preloads and creates normal size images component modal ready if needed. 
-        handleModalUris(results.get('uris'));
+        setUris(results.get('uris'));
         setResults(results.get('sets'));
     }
 

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -951,10 +951,15 @@ height: 2rem;
   min-height: inherit;
 }
 
+.slide .normal,
+.slide .reversible {
+  width: var(--slide-width);
+  height: var(--slide-heigth);
+  margin-inline: auto;
+}
+
 .reversible {
-  width: 100%;
-  height: 100%;
-  perspective: 1500px;
+  perspective: 1000px;
   background: transparent;
 }
 
@@ -1047,7 +1052,6 @@ height: 2rem;
 
 .slide {
   width: 100%;
-  perspective: 150rem;
   min-height: var(--slide-heigth);
 }
 


### PR DESCRIPTION
Added clear modal reducer function to reset modal props to initial state.
Moved uris from reducer state to its own setUris state. uris state is updated with each new search and does need to be reset upon modal closing. uris are needed if another card from the current search is  viewed in modal.
uris state is updated through setUris state defined @ ModalContext, and called @ useResults custom hook.